### PR TITLE
Add support for dossier database url

### DIFF
--- a/lib/dossier/adapter/active_record.rb
+++ b/lib/dossier/adapter/active_record.rb
@@ -16,6 +16,7 @@ module Dossier
       def execute(query, report_name = nil)
         retries ||= 0
 
+        connection.verify!
         Result.new(connection.exec_query(*["\n#{query}", report_name].compact))
       rescue PG::ConnectionBad => e
         if retries < 3
@@ -43,7 +44,7 @@ module Dossier
       def active_record_connection
         @abstract_class = Class.new(::ActiveRecord::Base) do
           self.abstract_class = true
-          
+
           # Needs a unique name for ActiveRecord's connection pool
           def self.name
             "Dossier::Adapter::ActiveRecord::Connection_#{object_id}"

--- a/lib/dossier/adapter/active_record.rb
+++ b/lib/dossier/adapter/active_record.rb
@@ -14,10 +14,19 @@ module Dossier
       end
 
       def execute(query, report_name = nil)
-        # Ensure that SQL logs show name of report generating query
-        Result.new(connection.exec_query(*["\n#{query}", report_name].compact))
+        new_result(connection, query, report_name)
+      rescue => e
+        # In case the error ocurred because of a faulty connection, we should
+        # aquire a new connection.
+        self.connection = active_record_connection
+        new_result(connection, query, report_name)
       rescue => e
         raise Dossier::ExecuteError.new "#{e.message}\n\n#{query}"
+      end
+
+      def new_result(connection, query, report_name)
+        # Ensure that SQL logs show name of report generating query
+        Result.new(connection.exec_query(*["\n#{query}", report_name].compact))
       end
 
       private

--- a/lib/dossier/configuration.rb
+++ b/lib/dossier/configuration.rb
@@ -24,7 +24,7 @@ module Dossier
     end
    
     def dburl_config
-      Dossier::ConnectionUrl.new.to_hash if ENV.has_key? DB_KEY
+      Dossier::ConnectionUrl.new(ENV['DOSSIER_DATABASE_URL']).to_hash if ENV.has_key? DB_KEY
     end
 
     private

--- a/lib/dossier/multi_report.rb
+++ b/lib/dossier/multi_report.rb
@@ -12,11 +12,12 @@ class Dossier::MultiReport
   end
 
   def initialize(options = {})
+    self.options = self.options.to_unsafe_h if self.options.respond_to?(:to_unsafe_h)
     self.options = options.dup.with_indifferent_access
   end
 
   def reports
-    @reports ||= self.class.reports.map { |report| 
+    @reports ||= self.class.reports.map { |report|
       report.new(options).tap { |r|
         r.parent = self
       }
@@ -30,7 +31,7 @@ class Dossier::MultiReport
   def formatter
     Module.new
   end
-  
+
   def dom_id
     nil
   end

--- a/lib/dossier/report.rb
+++ b/lib/dossier/report.rb
@@ -23,8 +23,9 @@ module Dossier
     def self.filename
       "#{report_name.parameterize}-report_#{Time.now.strftime('%Y-%m-%d_%H-%M-%S-%Z')}"
     end
-    
+
     def initialize(options = {})
+      options = options.to_unsafe_h if options.respond_to?(:to_unsafe_h)
       @options = options.dup.with_indifferent_access
     end
 
@@ -70,7 +71,7 @@ module Dossier
     def renderer
       @renderer ||= Renderer.new(self)
     end
-    
+
     delegate :render, to: :renderer
 
     private

--- a/lib/dossier/responder.rb
+++ b/lib/dossier/responder.rb
@@ -15,11 +15,13 @@ module Dossier
 
     def to_csv
       set_content_disposition!
+      set_content_type!('text/csv')
       controller.response_body = StreamCSV.new(*collection_and_headers(report.raw_results.arrays))
     end
 
     def to_xls
       set_content_disposition!
+      set_content_type!('application/xls')
       controller.response_body = Xls.new(*collection_and_headers(report.raw_results.arrays))
     end
 
@@ -27,13 +29,17 @@ module Dossier
       multi_report_html_only!
       super
     end
-    
+
     private
 
     def set_content_disposition!
       controller.headers["Content-Disposition"] = %[attachment;filename=#{filename}]
     end
-    
+
+    def set_content_type!(type)
+      controller.headers["Content-Type"] = %[#{type}; charset=utf-8]
+    end
+
     def collection_and_headers(collection)
       headers = collection.shift.map { |header| report.format_header(header) }
       [collection, headers]

--- a/lib/dossier/result.rb
+++ b/lib/dossier/result.rb
@@ -59,8 +59,8 @@ module Dossier
         }
       end
 
-      def each
-        adapter_results.rows.each { |row| yield format(row) }
+      def each(&block)
+        formatted_rows.each(&block)
       end
 
       def format(row)
@@ -75,6 +75,10 @@ module Dossier
       end
 
       private
+
+      def formatted_rows
+        @formatted_rows ||= adapter_results.rows.map { |row| format(row) }
+      end
 
       def displayable_columns(row)
         row.each_with_index.select { |value, i|


### PR DESCRIPTION
Allow using DOSSIER_DATABASE_URL to have dossier point to a different database.

    Dossier uses DATABASE_URL by default but Dossier::ConnectionUrl initializer
    allows you to pass a database URL:
        def initialize(url = nil)
          @uri = URI.parse(url || ENV.fetch('DATABASE_URL'))
        end

    However, when Dossier::Configuration gets the DB URL config, it does
    not pass in a URL to Dossier:ConnectionUrl:
        def dburl_config
          Dossier::ConnectionUrl.new.to_hash if ENV.has_key? DB_KEY
        end

    Notice the call to new has no url argument.

    By changing to the following:

        def dburl_config
          Dossier::ConnectionUrl.new(ENV['DOSSIER_DATABASE_URL']).to_hash if ENV.has_key? DB_KEY
        end

    We now allow ConnectionUrl to be initialized with DOSSIER_DATABASE_URL if one is present.
    If none, is present, ENV['DOSSIER_DATABASE_URL'] will return nil, and dossier will
    just use current behavior and fetch the DATABASE_URL

    This commit will allow users of Dossier on Heroku to add a new config for DOSSIER_DATABASE_URL
    to point dossier to a different database than the main application (e.g. a follower database).